### PR TITLE
Align magnification of selected panels

### DIFF
--- a/static/figure/js/models/figure_model.js
+++ b/static/figure/js/models/figure_model.js
@@ -322,7 +322,35 @@
                     new_h = ref_height;
                     new_w = (ref_height/p.get('height')) * p.get('width');
                 }
-                p.save({'width':new_w, 'height':new_h});
+                p.set({'width':new_w, 'height':new_h});
+            });
+        },
+
+        // Resize panels so they all show same magnification
+        align_magnification: function() {
+            var sel = this.getSelected(),
+                ref = this.get_top_left_panel(sel),
+                ref_pixSize = ref.get('pixel_size_x'),
+                targetMag;
+            console.log(ref_pixSize);
+            if (!ref_pixSize) {
+                alert('Top-left panel has no pixel size set');
+                return;
+            }
+            // E.g. 10 microns / inch
+            targetMag = ref_pixSize * ref.getPanelDpi();
+
+            sel.forEach(function(p){
+                var dpi = p.getPanelDpi(),
+                    pixSize = p.get('pixel_size_x');
+                if (!pixSize) {
+                    return;
+                }
+                var panelMag = dpi * pixSize,
+                    scale = panelMag / targetMag,
+                    new_w = p.get('width') * scale,
+                    new_h = p.get('height') * scale;
+                p.set({'width':new_w, 'height':new_h});
             });
         },
 

--- a/static/figure/js/models/figure_model.js
+++ b/static/figure/js/models/figure_model.js
@@ -332,7 +332,6 @@
                 ref = this.get_top_left_panel(sel),
                 ref_pixSize = ref.get('pixel_size_x'),
                 targetMag;
-            console.log(ref_pixSize);
             if (!ref_pixSize) {
                 alert('Top-left panel has no pixel size set');
                 return;

--- a/static/figure/js/views/figure_view.js
+++ b/static/figure/js/views/figure_view.js
@@ -676,6 +676,7 @@
             "click .awidth": "align_width",
             "click .aheight": "align_height",
             "click .asize": "align_size",
+            "click .amagnification": "align_magnification",
         },
 
         initialize: function() {
@@ -706,6 +707,11 @@
         align_size: function(event) {
             event.preventDefault();
             this.model.align_size(true, true);
+        },
+
+        align_magnification: function(event) {
+            event.preventDefault();
+            this.model.align_magnification();
         },
 
         align_top: function(event) {

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -425,6 +425,9 @@
                             <li><a href="#" class="asize">
                                 <span class="glyphicon glyphicon-fullscreen"></span> Width &amp; Height</a>
                             </li>
+                            <li><a href="#" class="amagnification">
+                                <span class="glyphicon glyphicon-fullscreen"></span> Align Magnification</a>
+                            </li>
                         </ul>
                     </div>
 


### PR DESCRIPTION
Fixes https://github.com/will-moore/figure/issues/34/

To test:
 - Select different sized panels with different zoom levels and pixel sizes.
 - Add similar sized scale bars to each, E.g. 5 microns.
 - Select panels and choose toolbar 'Align Sizes' > 'Align Magnification'.
 - All panels should be resized so that scale bars are same size in them all, using top-right panel as the reference.