### PR TITLE
Basic unit support

### DIFF
--- a/static/figure/js/models/panel_model.js
+++ b/static/figure/js/models/panel_model.js
@@ -16,6 +16,8 @@
             deltaT: [],     // list of deltaTs (secs) for tIndexes of movie
             rotation: 0,
             selected: false,
+            pixel_size_x_symbol: '&#181;m',     // microns by default
+            pixel_size_x_unit: 'MICROMETER',
 
             // model includes 'scalebar' object, e.g:
             // scalebar: {length: 10, position: 'bottomleft', color: 'FFFFFF',
@@ -68,6 +70,8 @@
                 'datasetName': data.datasetName,
                 'pixel_size_x': data.pixel_size_x,
                 'pixel_size_y': data.pixel_size_y,
+                'pixel_size_x_symbol': data.pixel_size.symbolX,
+                'pixel_size_x_unit': data.pixel_size.unitX,
                 'deltaT': data.deltaT,
             };
 

--- a/static/figure/js/models/panel_model.js
+++ b/static/figure/js/models/panel_model.js
@@ -16,7 +16,7 @@
             deltaT: [],     // list of deltaTs (secs) for tIndexes of movie
             rotation: 0,
             selected: false,
-            pixel_size_x_symbol: '&#181;m',     // microns by default
+            pixel_size_x_symbol: '\xB5m',     // microns by default
             pixel_size_x_unit: 'MICROMETER',
 
             // model includes 'scalebar' object, e.g:

--- a/static/figure/js/templates.js
+++ b/static/figure/js/templates.js
@@ -153,7 +153,9 @@ obj || (obj = {});
 var __t, __p = '', __e = _.escape, __j = Array.prototype.join;
 function print() { __p += __j.call(arguments, '') }
 with (obj) {
-__p += '\n    <div class="pixel_size_form" style="position:relative">\n        <div class="pixel_size_div">\n            Pixel Size:\n            <input class="input-sm form-control pixel_size_input" placeholder="Pixel Size (&#181;)"\n                    style="width:100px; display:none" value="' +
+__p += '\n    <div class="pixel_size_form" style="position:relative">\n        <div class="pixel_size_div">\n            Pixel Size:\n            <input class="input-sm form-control pixel_size_input" placeholder="Pixel Size (' +
+((__t = ( symbol )) == null ? '' : __t) +
+')"\n                    style="width:100px; display:none" value="' +
 ((__t = ( pixel_size_x )) == null ? '' : __t) +
 '">\n            <span class="pixel_size_display">\n                ';
  if (pixel_size_x == 0)
@@ -164,7 +166,9 @@ __p += '\n    <div class="pixel_size_form" style="position:relative">\n        <
                     {print(pixel_size_x + " &#181;m")} ;
 __p += '\n            </span>\n        </div>\n\n    </div>\n\n    <form class="scalebar_form form-inline">\n\n    <div class="input-group pull-left">\n        <input type="text" class="scalebar-length form-control input-sm" \n                placeholder="Length" value="' +
 ((__t = ( length )) == null ? '' : __t) +
-'" />\n    </div>\n\n    <div class="form-group"><div class="checkbox checkbox-inline">\n        <label>&#181;m</label>\n        </div>\n    </div>\n\n    <div class="btn-group">\n        <button type="button" class="label-position btn btn-default btn-sm dropdown-toggle" \n                title="Position" data-toggle="dropdown">\n            <span data-position="' +
+'" />\n    </div>\n\n    <div class="form-group"><div class="checkbox checkbox-inline">\n        <label>' +
+((__t = ( symbol )) == null ? '' : __t) +
+'</label>\n        </div>\n    </div>\n\n    <div class="btn-group">\n        <button type="button" class="label-position btn btn-default btn-sm dropdown-toggle" \n                title="Position" data-toggle="dropdown">\n            <span data-position="' +
 ((__t = ( position )) == null ? '' : __t) +
 '" class="labelicon-' +
 ((__t = ( position )) == null ? '' : __t) +
@@ -213,7 +217,9 @@ __p += '\n            <div class=\'scalebar-label\' style=\'color: #' +
 ((__t = ( font_size )) == null ? '' : __t) +
 'px\'>\n                ' +
 ((__t = ( length )) == null ? '' : __t) +
-' &#181;m\n            </div>\n        ';
+' ' +
+((__t = ( symbol )) == null ? '' : __t) +
+'\n            </div>\n        ';
  } ;
 __p += '\n    </div>\n';
 

--- a/static/figure/js/views/modal_views.js
+++ b/static/figure/js/views/modal_views.js
@@ -198,6 +198,8 @@
                     'datasetName': data.meta.datasetName,
                     'pixel_size_x': data.pixel_size.x,
                     'pixel_size_y': data.pixel_size.y,
+                    'pixel_size_x_unit': data.pixel_size.unitX,
+                    'pixel_size_x_symbol': data.pixel_size.symbolX,
                     'deltaT': data.deltaT,
                 };
                 self.newImg = newImg;
@@ -507,6 +509,8 @@
                         'datasetId': data.meta.datasetId,
                         'pixel_size_x': data.pixel_size.x,
                         'pixel_size_y': data.pixel_size.y,
+                        'pixel_size_x_symbol': data.pixel_size.symbolX,
+                        'pixel_size_x_unit': data.pixel_size.unitX,
                         'deltaT': data.deltaT,
                     };
                     if (baseUrl) {

--- a/static/figure/js/views/panel_view.js
+++ b/static/figure/js/views/panel_view.js
@@ -144,6 +144,7 @@
                 sb_json.length = sb.length;
                 sb_json.font_size = sb.font_size;
                 sb_json.show_label = sb.show_label;
+                sb_json.symbol = this.model.get('pixel_size_x_symbol');
 
                 var sb_html = this.scalebar_template(sb_json);
                 this.$el.append(sb_html);

--- a/static/figure/js/views/right_panel_view.js
+++ b/static/figure/js/views/right_panel_view.js
@@ -428,12 +428,16 @@
                 // start with json data from first Panel
                 if (!json.pixel_size_x) {
                     json.pixel_size_x = m.get('pixel_size_x');
+                    json.symbol = m.get('pixel_size_x_symbol');
                 } else {
                     pix_sze = m.get('pixel_size_x');
                     // account for floating point imprecision when comparing
                     if (json.pixel_size_x != '-' &&
                         json.pixel_size_x.toFixed(10) != pix_sze.toFixed(10)) {
                             json.pixel_size_x = '-';
+                    }
+                    if (json.symbol != m.get('pixel_size_x_symbol')) {
+                        json.symbol = '-';
                     }
                 }
                 sb = m.get('scalebar');
@@ -468,6 +472,7 @@
             json.position = json.position || 'bottomright';
             json.color = json.color || 'FFFFFF';
             json.font_size = json.font_size || 10;
+            json.symbol = json.symbol || '-';
 
             var html = this.template(json);
             this.$el.html(html);

--- a/static/figure/templates/scalebar_form_template.html
+++ b/static/figure/templates/scalebar_form_template.html
@@ -2,7 +2,7 @@
     <div class="pixel_size_form" style="position:relative">
         <div class="pixel_size_div">
             Pixel Size:
-            <input class="input-sm form-control pixel_size_input" placeholder="Pixel Size (&#181;)"
+            <input class="input-sm form-control pixel_size_input" placeholder="Pixel Size (<%= symbol %>)"
                     style="width:100px; display:none" value="<%= pixel_size_x %>">
             <span class="pixel_size_display">
                 <% if (pixel_size_x == 0)
@@ -24,7 +24,7 @@
     </div>
 
     <div class="form-group"><div class="checkbox checkbox-inline">
-        <label>&#181;m</label>
+        <label><%= symbol %></label>
         </div>
     </div>
 

--- a/static/figure/templates/scalebar_panel_template.html
+++ b/static/figure/templates/scalebar_panel_template.html
@@ -2,7 +2,7 @@
     <div class="scalebar label_<%= position %>" style="background-color: #<%= color %>">
         <% if (show_label) { %>
             <div class='scalebar-label' style='color: #<%= color %>; font-size: <%= font_size %>px'>
-                <%= length %> &#181;m
+                <%= length %> <%= symbol %>
             </div>
         <% } %>
     </div>

--- a/urls.py
+++ b/urls.py
@@ -47,4 +47,10 @@ urlpatterns = patterns('django.views.generic.simple',
 
     # Delete file annotations of saved Figures - 'POST' with 'fileId' of file annotation
     url( r'^delete_web_figure/$', views.delete_web_figure, name='delete_web_figure'),
+
+    # Converts Lengths of value in 'fromUnit' to 'toUnit'.
+    # E.g. unit_conversion/1.12/MICROMETER/ANGSTROM/.
+    # Returns result as json with keys of 'value', 'unit' and 'symbol'
+    url( r'^unit_conversion/(?P<value>[0-9.]+)/(?P<fromUnit>[A-Z]+)/(?P<toUnit>[A-Z]+)/$',
+            views.unit_conversion, name='unit_conversion'),
 )

--- a/views.py
+++ b/views.py
@@ -407,3 +407,34 @@ def delete_web_figure(request, conn=None, **kwargs):
     # fileAnn = conn.getObject("FileAnnotation", fileId)
     conn.deleteObjects("Annotation", [fileId])
     return HttpResponse("Deleted OK")
+
+def unit_conversion(request, value, fromUnit, toUnit, conn=None, **kwargs):
+    """
+    OMERO 5.1 only: Converts Lengths of value in 'fromUnit' to 'toUnit'.
+    E.g. unit_conversion/1.12/MICROMETER/ANGSTROM/.
+    Returns result as json with keys of 'value', 'unit' and 'symbol'
+    """
+
+    error = None
+    try:
+        from omero.model.enums import UnitsLength
+        fromUnit = getattr(UnitsLength, str(fromUnit))
+        toUnit = getattr(UnitsLength, str(toUnit))
+        value = float(value)
+    except ImportError, ex:
+        error = ("Failed to import omero.model.enums.UnitsLength."
+                 " Requires OMERO 5.1")
+    except AttributeError, ex:
+        error = ex.message
+
+    if error:
+        return HttpResponse(json.dumps({'error':error}), content_type='json')
+
+    fromValue = omero.model.LengthI(value, fromUnit)
+    toValue = omero.model.LengthI(fromValue, toUnit)
+
+    rsp = {'value': toValue.getValue(),
+           'unit': str(toValue.getUnit()),
+           'symbol': toValue.getSymbol()}
+
+    return HttpResponse(json.dumps(rsp), content_type='json')

--- a/views.py
+++ b/views.py
@@ -126,6 +126,9 @@ def imgData_json(request, imageId, conn=None, **kwargs):
     if unitsSupport:
         rv['pixel_size']['symbolX'] = px.getSymbol()
         rv['pixel_size']['unitX'] = str(px.getUnit())
+        py = image.getPrimaryPixels().getPhysicalSizeY()
+        rv['pixel_size']['symbolY'] = py.getSymbol()
+        rv['pixel_size']['unitY'] = str(py.getUnit())
     sizeT = image.getSizeT()
     timeList = []
     if sizeT > 1:

--- a/views.py
+++ b/views.py
@@ -335,17 +335,14 @@ def make_web_figure(request, conn=None, **kwargs):
     sId = scriptService.getScriptID(SCRIPT_PATH)
 
     figureJSON = request.POST.get('figureJSON')
-    # see https://github.com/will-moore/figure/issues/16
-    figureJSON = unicodedata.normalize('NFKD', figureJSON).encode('ascii','ignore')
     webclient_uri = request.build_absolute_uri(reverse('webindex'))
 
-    figure_dict = json.loads(figureJSON)
-
     inputMap = {
-        'Figure_JSON': wrap(figureJSON),
+        'Figure_JSON': wrap(figureJSON.encode('utf8')),
         'Webclient_URI': wrap(webclient_uri)}
 
     # If the figure has been saved, construct URL to it...
+    figure_dict = json.loads(figureJSON)
     if 'fileId' in figure_dict:
         try:
             figureUrl = reverse('load_figure', args=[figure_dict['fileId']])

--- a/views.py
+++ b/views.py
@@ -113,10 +113,19 @@ def index(request, fileId=None, conn=None, **kwargs):
 def imgData_json(request, imageId, conn=None, **kwargs):
 
     image = conn.getObject("Image", imageId)
+
+    # Test if we have Units support (OMERO 5.1)
+    px = image.getPrimaryPixels().getPhysicalSizeX()
+    pixSizeX = str(px)  # As string E.g. "0.13262 MICROMETER"
+    unitsSupport = " " in pixSizeX
+
     if image is None:
         raise Http404("Image not found")
     rv = imageMarshal(image)
 
+    if unitsSupport:
+        rv['pixel_size']['symbolX'] = px.getSymbol()
+        rv['pixel_size']['unitX'] = str(px.getUnit())
     sizeT = image.getSizeT()
     timeList = []
     if sizeT > 1:


### PR DESCRIPTION
Save units and symbols for pixel size X and Y. Use this simply for the Symbol shown in the Add Scalebar form and on scalebar label.
Also convert other units to MICROMETERS for the "Align Magnification" functionality.
Need to show correct symbols in PDF export on scalebar labels and in legend.