### PR TITLE
Panel background white

### DIFF
--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -387,6 +387,11 @@ def getPanelImage(image, panel):
         crop_top = int(dy * -2)
     else:
         crop_bottom = crop_bottom - int(dy * 2)
+
+    # convert to RGBA so we can control background after crop/rotate...
+    # See http://stackoverflow.com/questions/5252170/
+    mde = pilImg.mode
+    pilImg = pilImg.convert('RGBA')
     pilImg = pilImg.crop((crop_left, crop_top, crop_right, crop_bottom))
 
     # Optional rotation
@@ -407,7 +412,13 @@ def getPanelImage(image, panel):
 
     pilImg = pilImg.crop((crop_left, crop_top, crop_right, crop_bottom))
 
-    return pilImg
+    # ...paste image with transparent blank areas onto white background
+    fff = Image.new('RGBA', pilImg.size, (255, 255, 255, 255))
+    out = Image.composite(pilImg, fff, pilImg)
+    # and convert back to original mode
+    out.convert(mde)
+
+    return out
 
 
 def drawPanel(conn, c, panel, page, idx):

--- a/static/figure/css/figure.css
+++ b/static/figure/css/figure.css
@@ -72,7 +72,7 @@
 
     #figure .imagePanel {
         position: absolute;
-        background: #ddd;
+        background: #fff;
     }
 
     #figure .dragging{


### PR DESCRIPTION
In order that we have a consistent panel background colour between Web and PDF when a panel is rotated or panned too much. Previously the background on PDF was black and light grey in Web.
Now it is white on both (which also allows rotating of a panel without the border showing up).