### PR TITLE
Export images with pdf

### DIFF
--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -469,7 +469,7 @@ def drawPanel(conn, c, panel, page, idx, folder_name=None):
     # create name to save image
     originalName = image.getName()
     imgName = os.path.basename(originalName)
-    imgName = "%s_%s.png" % (idx, imgName)
+    imgName = "%s_%s.tiff" % (idx, imgName)
 
     # get cropped image (saving original)
     origName = None

--- a/static/figure/js/views/figure_view.js
+++ b/static/figure/js/views/figure_view.js
@@ -82,6 +82,7 @@
 
         events: {
             "click .export_pdf": "export_pdf",
+            "click .export_options li": "export_options",
             "click .add_panel": "addPanel",
             "click .delete_panel": "deleteSelectedPanels",
             "click .copy": "copy_selected_panels",
@@ -111,6 +112,21 @@
             'up' : 'nudge_up',
             'left' : 'nudge_left',
             'right' : 'nudge_right',
+        },
+
+        // choose an export option from the drop-down list
+        export_options: function(event) {
+            event.preventDefault();
+
+            var $target = $(event.target);
+
+            // Only show check mark on the selected item.
+            $(".export_options .glyphicon-ok").css('visibility', 'hidden');
+            $(".glyphicon-ok", $target).css('visibility', 'visible');
+
+            // Update text of main export_pdf button.
+            var txt = $target.attr('data-label');
+            $('.export_pdf').text("Export " + txt);
         },
 
         paper_setup: function(event) {

--- a/static/figure/js/views/figure_view.js
+++ b/static/figure/js/views/figure_view.js
@@ -125,8 +125,8 @@
             $(".glyphicon-ok", $target).css('visibility', 'visible');
 
             // Update text of main export_pdf button.
-            var txt = $target.attr('data-label');
-            $('.export_pdf').text("Export " + txt);
+            var txt = $target.attr('data-export-option');
+            $('.export_pdf').text("Export " + txt).attr('data-export-option', txt);
         },
 
         paper_setup: function(event) {
@@ -148,18 +148,27 @@
             // Status is indicated by showing / hiding 3 buttons
             var figureModel = this.model,
                 $create_figure_pdf = $(event.target),
+                export_opt = $create_figure_pdf.attr('data-export-option'),
                 $pdf_inprogress = $("#pdf_inprogress"),
-                $pdf_download = $("#pdf_download");
+                $pdf_download = $("#pdf_download"),
+                exportOption = "PDF";
             $create_figure_pdf.hide();
             $pdf_download.hide();
             $pdf_inprogress.show();
+
+            if (export_opt == "PDF & images") {
+                exportOption = "PDF_IMAGES";
+            } else {
+                exportOption = "PDF";
+            }
 
             // Get figure as json
             var figureJSON = this.model.figure_toJSON();
 
             var url = MAKE_WEBFIGURE_URL,
                 data = {
-                    figureJSON: JSON.stringify(figureJSON)
+                    figureJSON: JSON.stringify(figureJSON),
+                    exportOption: exportOption,
                 };
 
             // Start the Figure_To_Pdf.py script

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -484,6 +484,7 @@
                     <div class="btn-group" {% if scriptMissing %}title="PDF script not installed"{% endif %}>
                         <button id="create_figure_pdf" title="Generate PDF for download"
                             {% if scriptMissing %}disabled="disabled"{% endif %}
+                            data-export-option="PDF"
                             type="button" class="btn btn-success btn-sm export_pdf">
                             Export PDF
                         </button>
@@ -492,11 +493,12 @@
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu export_options" role="menu">
-                            <li><a href="#" class="js-export-pdf-only" data-label="PDF">
+                            <!-- NB: data-export-option attr used to label export button & handled by js on click -->
+                            <li><a href="#" class="js-export-pdf-only" data-export-option="PDF">
                                 <span class="glyphicon glyphicon-ok" style="color:#333"></span>
                                 PDF only</a>
                             </li>
-                            <li><a href="#" class="js-export-pdf-images" data-label="PDF & images">
+                            <li><a href="#" class="js-export-pdf-images" data-export-option="PDF & images">
                                 <span class="glyphicon glyphicon-ok" style="color:#333; visibility:hidden"></span>
                                 PDF with images</a>
                             </li>

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -484,7 +484,23 @@
                     <div class="btn-group" {% if scriptMissing %}title="PDF script not installed"{% endif %}>
                         <button id="create_figure_pdf" title="Generate PDF for download"
                             {% if scriptMissing %}disabled="disabled"{% endif %}
-                            type="button" class="btn btn-success btn-sm export_pdf">Export PDF</button>
+                            type="button" class="btn btn-success btn-sm export_pdf">
+                            Export PDF
+                        </button>
+                        <button type="button" class="btn btn-success btn-sm dropdown-toggle" title="Export Options"
+                            data-toggle="dropdown">
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu export_options" role="menu">
+                            <li><a href="#" class="js-export-pdf-only" data-label="PDF">
+                                <span class="glyphicon glyphicon-ok" style="color:#333"></span>
+                                PDF only</a>
+                            </li>
+                            <li><a href="#" class="js-export-pdf-images" data-label="PDF & images">
+                                <span class="glyphicon glyphicon-ok" style="color:#333; visibility:hidden"></span>
+                                PDF with images</a>
+                            </li>
+                        </ul>
                     </div>
                 </form>
             </div><!--/.navbar-collapse -->

--- a/views.py
+++ b/views.py
@@ -335,10 +335,12 @@ def make_web_figure(request, conn=None, **kwargs):
     sId = scriptService.getScriptID(SCRIPT_PATH)
 
     figureJSON = request.POST.get('figureJSON')
+    exportOption = request.POST.get('exportOption')     # E.g. "PDF", "PDF_IMAGES"
     webclient_uri = request.build_absolute_uri(reverse('webindex'))
 
     inputMap = {
         'Figure_JSON': wrap(figureJSON.encode('utf8')),
+        'Export_Option': wrap(str(exportOption)),
         'Webclient_URI': wrap(webclient_uri)}
 
     # If the figure has been saved, construct URL to it...


### PR DESCRIPTION
Export option allows users to export the images used in a Figure alongside the PDF figure itself (as a zip).
For each panel this includes the Original rendered image and well as the cropped & rotated panel that was embedded in the PDF (both as tifffs). This gives greater clarity to the process of figure creation and also allows users to update the PDF with edited versions of the images within it.