### PR TITLE
render_to_response uses RequestContext

### DIFF
--- a/views.py
+++ b/views.py
@@ -18,6 +18,7 @@
 
 from django.http import Http404, HttpResponse
 from django.shortcuts import render_to_response
+from django.template import RequestContext
 from datetime import datetime
 import unicodedata
 import json
@@ -106,7 +107,8 @@ def index(request, fileId=None, conn=None, **kwargs):
 
     context = {'scriptMissing': scriptMissing,
             'userFullName': userFullName}
-    return render_to_response("figure/index.html", context)
+    return render_to_response("figure/index.html", context,
+            context_instance=RequestContext(request))
 
 
 @login_required()


### PR DESCRIPTION
This is https://github.com/will-moore/figure/pull/63 rebased onto master.

This adds RequestContext to render_to_response, making it compatible with changes in openmicroscopy/openmicroscopy#3629.