### PR TITLE
Crop dialog fixes

### DIFF
--- a/static/figure/css/figure.css
+++ b/static/figure/css/figure.css
@@ -701,6 +701,14 @@
         z-index: 10;
     }
 
+    .roiPickMe {
+        cursor: pointer;
+    }
+    /* On hover, use selected blue color */
+    .roiPickMe:hover {
+        background-color: rgb(190, 212, 253);
+    }
+
 
     /*  color-picker  */
 

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -18,6 +18,8 @@ var RoiModalView = Backbone.View.extend({
                 self.listenTo(self.m, 'change:theZ change:theT', self.render);
                 self.cropModel.set({'selected': false, 'width': 0, 'height': 0});    // hide crop roi
                 self.zoomToFit();   // includes render()
+                // disable submit until user chooses a region/ROI
+                self.enableSubmit(false);
                 self.loadRois();
             });
 
@@ -48,6 +50,8 @@ var RoiModalView = Backbone.View.extend({
                 }
                 // No-longer correspond to saved ROI coords
                 self.currentRoiId = undefined;
+                // Allow submit of dialog
+                this.enableSubmit(true);
             });
 
             // Now set up Raphael paper...
@@ -62,6 +66,16 @@ var RoiModalView = Backbone.View.extend({
             "mousemove svg": "mousemove",
             "mouseup svg": "mouseup",
             "submit .roiModalForm": "handleRoiForm"
+        },
+
+        // we disable Submit when dialog is shown, enable when region/ROI chosen
+        enableSubmit: function(enabled) {
+            var $okBtn = $('button[type="submit"]', this.$el);
+            if (enabled) {
+                $okBtn.prop('disabled', false);
+            } else {
+                $okBtn.prop('disabled', 'disabled');
+            }
         },
 
         roiPicked: function(event) {

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -235,6 +235,13 @@ var RoiModalView = Backbone.View.extend({
                     roi, shape, theT, theZ, z, t, rect, tkeys, zkeys,
                     minT, maxT,
                     shapes; // dict of all shapes by z & t index
+                if (data.length === 0) {
+                    $("#cropRoiMessage").text("[No rectangular ROIs found on this image in OMERO]").show();
+                    $(".roiPicker").hide();
+                } else {
+                    $("#cropRoiMessage").text("").hide();
+                    $(".roiPicker").show();
+                }
                 for (var r=0; r<data.length; r++) {
                     roi = data[r];
                     shapes = {};

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -61,7 +61,7 @@ var RoiModalView = Backbone.View.extend({
         },
 
         events: {
-            "click .roi_content": "roiPicked",
+            "click .roiPickMe": "roiPicked",
             "mousedown svg": "mousedown",
             "mousemove svg": "mousemove",
             "mouseup svg": "mouseup",
@@ -80,7 +80,11 @@ var RoiModalView = Backbone.View.extend({
 
         roiPicked: function(event) {
 
-            var $roi = $(event.target),
+            var $target = $(event.target),
+                $tr = $target.parent();
+            // $tr might be first <td> if img clicked or <tr> if td clicked
+            // but in either case it will contain the img we need.
+            var $roi = $tr.find('img.roi_content'),
                 x = parseInt($roi.attr('data-x'), 10),
                 y = parseInt($roi.attr('data-y'), 10),
                 width = parseInt($roi.attr('data-width'), 10),

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -174,7 +174,8 @@ var RoiModalView = Backbone.View.extend({
                 var sh = getShape(m.get('theZ'), m.get('theT'));
 
                 m.cropToRoi({'x': sh.x, 'y': sh.y, 'width': sh.width, 'height': sh.height});
-                m.set({'theZ': parseInt(sh.theZ, 10),
+                // 'save' to trigger 'unsaved': true
+                m.save({'theZ': parseInt(sh.theZ, 10),
                        'theT': parseInt(sh.theT, 10)});
             });
             $("#roiModal").modal('hide');

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -201,6 +201,8 @@
                 <form class="roiModalForm" role="form">
                     <div class="modal-body" style="height: 500px; max-height: 500px">
                         <div class="col-xs-4" style="height: 500px; overflow: auto">
+                            <p>Click and drag on the image to choose a crop region
+                                or pick an ROI from the list below.</p>
                             <h4>ROIs</h4>
                             <table class="roiPicker table table-condensed">
                                 <thead><td></td><td>Z-index</td><td>T-index</td></thead>

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -201,8 +201,10 @@
                 <form class="roiModalForm" role="form">
                     <div class="modal-body" style="height: 500px; max-height: 500px">
                         <div class="col-xs-4" style="height: 500px; overflow: auto">
-                            <p>Click and drag on the image to choose a crop region
-                                or pick an ROI from the list below.</p>
+                            <p>
+                                Click and drag on the image to choose a crop region or
+                                pick an ROI from the list below.
+                            </p>
                             <h4>ROIs</h4>
                             <table class="roiPicker table table-condensed">
                                 <thead><td></td><td>Z-index</td><td>T-index</td></thead>
@@ -210,6 +212,8 @@
                                 <!-- ROIs loaded here... -->
                                 </tbody>
                             </table>
+                            <!-- Additional message depends on whether we have any ROIs or not -->
+                            <p id='cropRoiMessage'></p>
                         </div>
                         <div class="col-xs-8">
                             <div id="roiViewer">

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -225,7 +225,7 @@
                     </div>
                     <div class="modal-footer" style="margin-top: 0">
                         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                        <button type="submit" class="btn btn-primary">OK</button>
+                        <button type="submit" class="btn btn-primary" disabled="disabled">OK</button>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
Addresses several points raised during OMERO.figure testing of the crop dialog:
To test:

 - Crop dialog now has a short message instructing user to drag to select a region or pick ROI.
 - If no ROIs on the image, show a message to indicate it.
 - Dialog "OK" is disabled when the dialog is first shown and is only enabled when an ROI is picked or a region is selected.
 - ROIs can be selected by clicking on the whole ROI row (don't need to click thumbnail) and this is indicated by mouse pointer and hover colour change.