### PR TITLE
Show pixel size with correct unit symbol

### DIFF
--- a/static/figure/js/templates.js
+++ b/static/figure/js/templates.js
@@ -165,7 +165,7 @@ __p += '\n    <div class="pixel_size_form" style="position:relative">\n        <
  if (pixel_size_x == 0)
                     {print('<span style="color:red">NOT SET</span>')}
                 else if (typeof pixel_size_x === 'number')
-                    {print(pixel_size_x.toFixed(3) + " &#181;m")}
+                    {print(pixel_size_x.toFixed(3) + " " + symbol)}
                 else
                     {print(pixel_size_x + " &#181;m")} ;
 __p += '\n            </span>\n        </div>\n\n    </div>\n\n    <form class="scalebar_form form-inline">\n\n    <div class="input-group pull-left">\n        <input type="text" class="scalebar-length form-control input-sm" \n                placeholder="Length" value="' +

--- a/static/figure/templates/scalebar_form_template.html
+++ b/static/figure/templates/scalebar_form_template.html
@@ -8,7 +8,7 @@
                 <% if (pixel_size_x == 0)
                     {print('<span style="color:red">NOT SET</span>')}
                 else if (typeof pixel_size_x === 'number')
-                    {print(pixel_size_x.toFixed(3) + " &#181;m")}
+                    {print(pixel_size_x.toFixed(3) + " " + symbol)}
                 else
                     {print(pixel_size_x + " &#181;m")} %>
             </span>


### PR DESCRIPTION
Fixes issue reported in pre-release testing.
Show unit symbol beside pixel size display (see screenshot):

![screen shot 2015-04-14 at 22 22 10](https://cloud.githubusercontent.com/assets/900055/7147714/d8609c44-e2f4-11e4-8f44-4374e6efbe3a.png)
