### PR TITLE
Improve 'markdown info' dialog

### DIFF
--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -370,20 +370,38 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">Markdown Formatting</h4>
+                    <h4 class="modal-title">Legend Formatting</h4>
                 </div>
                 <div class="modal-body">
                     <p>
-                        Markdown syntax allows you to add formatting in plain text. For example,
-                        **this text will be bold** and this word will be *italic*.
+                        You can use "Markdown" syntax to add formatting to plain text. For example,
+                        **this text will be bold** and this *word* will be italic.
                     </p>
 
                     <table class="table">
-                        <tr><th>BOLD</th> <td>**Bolded text here**</td></tr>
-                        <tr><th>ITALIC</th> <td>*Italic text here*</td></tr>
-                        <tr><th>LINK</th> <td>[Link text](http://link_url.com)</td></tr>
-                        <tr><th>PARAGRAPHS</th> <td>You need to use 2 line breaks between paragraphs</td></tr>
+                        <tr>
+                            <td></td>
+                            <th>This text will be formatted to...</th>
+                            <th>...this text</th></tr>
+                        <tr>
+                            <th>BOLD</th>
+                            <td>Use 2 stars for **bold**.</td>
+                            <td>Use 2 stars for <strong>bold</strong>.</td>
+                        </tr>
+                        <tr>
+                            <th>ITALIC</th>
+                            <td>Use 1 star for *italic*.</td>
+                            <td>Use 1 star for <i>italic</i>.</td>
+                        </tr>
+                        <tr>
+                            <th>LINKS</th>
+                            <td>Add links with [Link text](http://link_url.com)</td>
+                            <td>Add links with <a href="http://link_url.com">Link text</a></td>
+                        </tr>
+                       <!--  <tr><td>You need to use 2 line breaks between paragraphs</td><td></td></tr> -->
                     </table>
+                    <p>The figure legend will be included in the PDF info page when the figure is
+                        exported.</p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
@@ -666,7 +684,7 @@
             </button>
             <button type="button" class="btn btn-link pull-right markdown-info"
                     title="Use Markdown formatting. Click for more info...">
-                Markdown supported
+                Legend formatting
             </button>
             <div class="legend panel-body">
                 <p>


### PR DESCRIPTION
Feedback from Michael: most users won't know what markdown is: Make the info dialog more user-friendly.

![screen shot 2015-04-14 at 23 07 05](https://cloud.githubusercontent.com/assets/900055/7148480/27475e28-e2fb-11e4-814c-2cc4c609e3fa.png)
