### PR TITLE
Fix pixelated css and add to viewport

### DIFF
--- a/static/figure/css/figure.css
+++ b/static/figure/css/figure.css
@@ -51,12 +51,20 @@
         z-index: 1;
         background-color: #EFF1F4;
         position: absolute;
+    }
+
+    .pixelated {
         /* Try to show images in their original pixelated form Although 'pixelated' isn't 
-        supported yet: https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering */
-        image-rendering: -moz-crisp-edges;
-        image-rendering: -o-crisp-edges;
-        image-rendering: -webkit-optimize-contrast;
-        -ms-interpolation-mode: nearest-neighbor;
+        supported yet: https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering
+        Code from http://phrogz.net/tmp/canvas_image_zoom.html */
+        image-rendering:optimizeSpeed;             /* Legal fallback */
+        image-rendering:-moz-crisp-edges;          /* Firefox        */
+        image-rendering:-o-crisp-edges;            /* Opera          */
+        image-rendering:-webkit-optimize-contrast; /* Safari         */
+        image-rendering:optimize-contrast;         /* CSS3 Proposed  */
+        image-rendering:crisp-edges;               /* CSS4 Proposed  */
+        image-rendering:pixelated;                 /* CSS4 Proposed  */
+        -ms-interpolation-mode:nearest-neighbor;   /* IE8+           */
     }
 
     /* #figure is a container of .paper */

--- a/static/figure/js/templates.js
+++ b/static/figure/js/templates.js
@@ -252,7 +252,7 @@ __p += '\n        <div id="vp_z_label">Z</div>\n        <div id="vp_z_value">' +
 ((__t = ( frame_h )) == null ? '' : __t) +
 'px">\n            ';
  _.each(imgs_css, function(css, i) { ;
-__p += '\n            <img class="vp_img"\n                style="opacity:' +
+__p += '\n            <img class="vp_img pixelated"\n                style="opacity:' +
 ((__t = ( opacity )) == null ? '' : __t) +
 '; left:' +
 ((__t = ( css.left )) == null ? '' : __t) +

--- a/static/figure/templates/viewport_template.html
+++ b/static/figure/templates/viewport_template.html
@@ -6,7 +6,7 @@
         <div id="vp_deltaT"><%= deltaT %></div>
         <div class="vp_frame" style="width:<%= frame_w %>px; height:<%= frame_h %>px">
             <% _.each(imgs_css, function(css, i) { %>
-            <img class="vp_img"
+            <img class="vp_img pixelated"
                 style="opacity:<%= opacity %>; left:<%= css.left %>px; top:<%= css.top %>px;
                     width:<%= css.width %>px; height:<%= css.height %>px;
                     -webkit-transform-origin:<%= css['transform-origin'] %>;

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -646,7 +646,7 @@
     <main>
         <div id="canvas_wrapper" class="canvas_wrapper">
             <!-- <div id="canvas_overlay"></div> -->
-            <article id="canvas">
+            <article id="canvas" class="pixelated">
                 <div id="figure">
                     <!-- All panels etc are appended to figure. -->
                     <!-- We also dynamically add <div class="paper"> -->


### PR DESCRIPTION
Improve pixelated css styles to remove interpolation when zooming main figure and viewport.
Both now show pixelation at low dpi levels:

![screen shot 2015-04-14 at 23 31 47](https://cloud.githubusercontent.com/assets/900055/7148828/a07e44b6-e2fe-11e4-8b65-b4659c772a05.png)
