### PR TITLE
Zero sized crop region

### DIFF
--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -50,8 +50,12 @@ var RoiModalView = Backbone.View.extend({
                 }
                 // No-longer correspond to saved ROI coords
                 self.currentRoiId = undefined;
-                // Allow submit of dialog
-                this.enableSubmit(true);
+                // Allow submit of dialog if valid ROI
+                if (self.currentROI.width < 2 || self.currentROI.height < 2) {
+                    self.enableSubmit(false);
+                } else {
+                    self.enableSubmit(true);
+                }
             });
 
             // Now set up Raphael paper...
@@ -73,8 +77,10 @@ var RoiModalView = Backbone.View.extend({
             var $okBtn = $('button[type="submit"]', this.$el);
             if (enabled) {
                 $okBtn.prop('disabled', false);
+                $okBtn.prop('title', 'Crop selected images to chosen region');
             } else {
                 $okBtn.prop('disabled', 'disabled');
+                $okBtn.prop('title', 'No valid region selected');
             }
         },
 

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -139,6 +139,11 @@ var RoiModalView = Backbone.View.extend({
 
             var getShape = function getShape(z, t) {
 
+                // If all on one T-index, update to the current
+                // T-index that we're looking at.
+                if (sameT) {
+                    t = self.m.get('theT');
+                }
                 var rv = {'x': r.x,
                         'y': r.y,
                         'width': r.width,

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -51,10 +51,10 @@ var RoiModalView = Backbone.View.extend({
                 // No-longer correspond to saved ROI coords
                 self.currentRoiId = undefined;
                 // Allow submit of dialog if valid ROI
-                if (self.currentROI.width < 2 || self.currentROI.height < 2) {
-                    self.enableSubmit(false);
-                } else {
+                if (self.regionValid(self.currentROI)) {
                     self.enableSubmit(true);
+                } else {
+                    self.enableSubmit(false);
                 }
             });
 
@@ -82,6 +82,18 @@ var RoiModalView = Backbone.View.extend({
                 $okBtn.prop('disabled', 'disabled');
                 $okBtn.prop('title', 'No valid region selected');
             }
+        },
+
+        // Region is only valid if it has width & height > 1 and
+        // is at least partially overlapping with the image
+        regionValid: function(roi) {
+
+            if (roi.width < 2 || roi.height < 2) return false;
+            if (roi.x > this.m.get('orig_width')) return false;
+            if (roi.y > this.m.get('orig_height')) return false;
+            if (roi.x + roi.width < 0) return false;
+            if (roi.y + roi.height < 0) return false;
+            return true;
         },
 
         roiPicked: function(event) {


### PR DESCRIPTION
This PR ensures that the "OK" submit button on the crop dialog is not enabled when the region selected is zero or 1 pixel width or height.
To test:

 - Open crop dialog, single click on image to add region that has zero width & height.
 - OK button should be disabled.
 - With a larger region, it is possible to drag the region outside of the area of the image.
 - This should also disable the OK button.