### PR TITLE
Show 'Pixel Size NOT SET' instead of 'null'

### DIFF
--- a/static/figure/js/templates.js
+++ b/static/figure/js/templates.js
@@ -162,7 +162,7 @@ __p += '\n    <div class="pixel_size_form" style="position:relative">\n        <
 ')"\n                    style="width:100px; display:none" value="' +
 ((__t = ( pixel_size_x )) == null ? '' : __t) +
 '">\n            <span class="pixel_size_display">\n                ';
- if (pixel_size_x == 0)
+ if (!pixel_size_x)
                     {print('<span style="color:red">NOT SET</span>')}
                 else if (typeof pixel_size_x === 'number')
                     {print(pixel_size_x.toFixed(3) + " " + symbol)}

--- a/static/figure/templates/scalebar_form_template.html
+++ b/static/figure/templates/scalebar_form_template.html
@@ -5,7 +5,7 @@
             <input class="input-sm form-control pixel_size_input" placeholder="Pixel Size (<%= symbol %>)"
                     style="width:100px; display:none" value="<%= pixel_size_x %>">
             <span class="pixel_size_display">
-                <% if (pixel_size_x == 0)
+                <% if (!pixel_size_x)
                     {print('<span style="color:red">NOT SET</span>')}
                 else if (typeof pixel_size_x === 'number')
                     {print(pixel_size_x.toFixed(3) + " " + symbol)}


### PR DESCRIPTION
Small fix to display of pixel size when it's not set.
Shows 'NOT SET' instead of 'null'.

![screen shot 2015-04-16 at 23 00 43](https://cloud.githubusercontent.com/assets/900055/7192351/921e9666-e48c-11e4-9280-5a45e328186b.png)
