### PR TITLE
If dpi is set, don't pixelate images

### DIFF
--- a/static/figure/js/templates.js
+++ b/static/figure/js/templates.js
@@ -252,7 +252,11 @@ __p += '\n        <div id="vp_z_label">Z</div>\n        <div id="vp_z_value">' +
 ((__t = ( frame_h )) == null ? '' : __t) +
 'px">\n            ';
  _.each(imgs_css, function(css, i) { ;
-__p += '\n            <img class="vp_img pixelated"\n                style="opacity:' +
+__p += '\n            <img class="vp_img';
+ if (css.pixelated) {;
+__p += ' pixelated';
+ } ;
+__p += '"\n                style="opacity:' +
 ((__t = ( opacity )) == null ? '' : __t) +
 '; left:' +
 ((__t = ( css.left )) == null ? '' : __t) +

--- a/static/figure/js/views/panel_view.js
+++ b/static/figure/js/views/panel_view.js
@@ -18,7 +18,9 @@
                 'change:x change:y change:width change:height change:zoom change:dx change:dy change:rotation',
                 this.render_layout);
             this.listenTo(this.model, 'change:scalebar change:pixel_size_x', this.render_scalebar);
-            this.listenTo(this.model, 'change:channels change:theZ change:theT change:z_start change:z_end change:z_projection', this.render_image);
+            this.listenTo(this.model,
+                'change:channels change:theZ change:theT change:z_start change:z_end change:z_projection change:export_dpi',
+                this.render_image);
             this.listenTo(this.model, 'change:labels change:theT change:deltaT', this.render_labels);
             // This could be handled by backbone.relational, but do it manually for now...
             // this.listenTo(this.model.channels, 'change', this.render);
@@ -82,6 +84,13 @@
         render_image: function() {
             var src = this.model.get_img_src();
             this.$img_panel.attr('src', src);
+
+            // if a 'reasonable' dpi is set, we don't pixelate
+            if (this.model.get('export_dpi') > 100) {
+                this.$img_panel.removeClass('pixelated');
+            } else {
+                this.$img_panel.addClass('pixelated');
+            }
         },
 
         render_labels: function() {

--- a/static/figure/js/views/right_panel_view.js
+++ b/static/figure/js/views/right_panel_view.js
@@ -712,7 +712,7 @@
 
             this.models.forEach(function(m){
                 self.listenTo(m,
-                    'change:width change:height change:channels change:zoom change:theZ change:theT change:rotation change:z_projection change:z_start change:z_end',
+                    'change:width change:height change:channels change:zoom change:theZ change:theT change:rotation change:z_projection change:z_start change:z_end change:export_dpi',
                     self.render);
                 zoom_sum += m.get('zoom');
 
@@ -904,6 +904,9 @@
                 var src = m.get_img_src(),
                     img_css = m.get_vp_img_css(m.get('zoom'), frame_w, frame_h, m.get('dx'), m.get('dy'));
                 img_css.src = src;
+                // if a 'reasonable' dpi is set, we don't pixelate
+                dpiSet = m.get('export_dpi') > 100;
+                img_css.pixelated = !dpiSet;
                 imgs_css.push(img_css);
             });
 

--- a/static/figure/templates/viewport_template.html
+++ b/static/figure/templates/viewport_template.html
@@ -6,7 +6,7 @@
         <div id="vp_deltaT"><%= deltaT %></div>
         <div class="vp_frame" style="width:<%= frame_w %>px; height:<%= frame_h %>px">
             <% _.each(imgs_css, function(css, i) { %>
-            <img class="vp_img pixelated"
+            <img class="vp_img<% if (css.pixelated) {%> pixelated<% } %>"
                 style="opacity:<%= opacity %>; left:<%= css.left %>px; top:<%= css.top %>px;
                     width:<%= css.width %>px; height:<%= css.height %>px;
                     -webkit-transform-origin:<%= css['transform-origin'] %>;

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -664,7 +664,7 @@
     <main>
         <div id="canvas_wrapper" class="canvas_wrapper">
             <!-- <div id="canvas_overlay"></div> -->
-            <article id="canvas" class="pixelated">
+            <article id="canvas">
                 <div id="figure">
                     <!-- All panels etc are appended to figure. -->
                     <!-- We also dynamically add <div class="paper"> -->


### PR DESCRIPTION
Indicate which images have 'export_dpi' set by interpolating images as will be in the exported PDF.

![screen shot 2015-04-16 at 23 46 38](https://cloud.githubusercontent.com/assets/900055/7192997/32c5cf70-e493-11e4-8680-b39e144e5709.png)
