### PR TITLE
Fix potential bug with adding big images to small paper

### DIFF
--- a/static/figure/js/views/modal_views.js
+++ b/static/figure/js/views/modal_views.js
@@ -501,7 +501,7 @@
                     coords.spacer = coords.spacer || data.size.width/20;
                     var full_width = (coords.colCount * (data.size.width + coords.spacer)) - coords.spacer,
                         full_height = (coords.rowCount * (data.size.height + coords.spacer)) - coords.spacer;
-                    coords.scale = (coords.paper_width - (2 * coords.spacer)) / full_width;
+                    coords.scale = coords.paper_width / (full_width + (2 * coords.spacer));
                     coords.scale = Math.min(coords.scale, 1);    // only scale down
                     coords.px = coords.px || coords.c.x - (full_width * coords.scale)/2;
                     coords.py = coords.py || coords.c.y - (full_height * coords.scale)/2;


### PR DESCRIPTION
See https://github.com/will-moore/figure/issues/37
If a large image is added to a much smaller paper then we could end up with a negative scale number because the spacer around the image (image_width/20) was first subtracted from paper width before scaling. This is fixed by the first commit below.