### PR TITLE
1 1 followup fixes

### DIFF
--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -56,6 +56,24 @@ ORIGINAL_DIR = "1_originals"
 RESAMPLED_DIR = "2_pre_resampled"
 FINAL_DIR = "3_final"
 
+README_TXT = """These folders contain images used in the creation
+of the figure. Each folder contains one image per figure panel,
+with images numbered according to the order they were added to
+the figure. The numbered folders represent the sequence of
+processing steps:
+
+ - 1_originals: This contains the full-sized and un-cropped images that are
+   rendered by OMERO according to your chosen rendering settings.
+
+ - 2_pre_resampled: This folder will only contain those images that are
+   resampled in order to match the export figure resolution. This will be
+   all panels for export of TIFF figures, or individual panels that have
+   a 'dpi' set for export of PDF figures.
+
+ - 3_final: These are the image panels that are inserted into the
+   final figure, saved following any cropping, rotation and resampling steps.
+"""
+
 
 def compress(target, base):
     """
@@ -196,6 +214,7 @@ class FigureExport(object):
                 for d in (ORIGINAL_DIR, RESAMPLED_DIR, FINAL_DIR):
                     imgDir = os.path.join(zipDir, d)
                     os.mkdir(imgDir)
+                self.addReadMeFile()
 
         # Create the figure file(s)
         self.createFigure()
@@ -738,6 +757,15 @@ class FigureExport(object):
             indent = indent + imgw + spacer
         para.drawOn(c, indent, pageY - h)
         return pageY - parah - spacer # reduce the available height
+
+    def addReadMeFile(self):
+        """ Add a simple text file into the zip to explain what's there """
+        readMePath = os.path.join(self.zip_folder_name, "README.txt")
+        f = open(readMePath, 'w')
+        try:
+            f.write(README_TXT)
+        finally:
+            f.close()
 
     def addInfoPage(self, panels_json):
         """ Generates a PDF info page with figure title, links to images etc """

--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -562,7 +562,7 @@ class FigureExport(object):
         else:
             lx_end = lx - canvas_length
 
-        self.drawLine(lx, ly, lx_end, ly, 2, (red, green, blue))
+        self.drawLine(lx, ly, lx_end, ly, 3, (red, green, blue))
 
         if 'show_label' in sb and sb['show_label']:
             # c = self.figureCanvas

--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -31,7 +31,8 @@ from cStringIO import StringIO
 try:
     from PIL import Image, ImageDraw, ImageFont
 except ImportError:
-    import Image, ImageDraw
+    import Image
+    import ImageDraw
 
 try:
     import markdown
@@ -127,7 +128,7 @@ class FigureExport(object):
     def getZipName(self):
 
         # file names can't include unicode characters
-        name = unicodedata.normalize('NFKD', self.figureName).encode('ascii','ignore')
+        name = unicodedata.normalize('NFKD', self.figureName).encode('ascii', 'ignore')
         # in case we have path/to/name.pdf, just use name.pdf
         name = path.basename(name)
         # Remove commas: causes problems 'duplicate headers' in file download
@@ -147,7 +148,7 @@ class FigureExport(object):
         fext = self.getFigureFileExt()
 
         # file names can't include unicode characters
-        name = unicodedata.normalize('NFKD', self.figureName).encode('ascii','ignore')
+        name = unicodedata.normalize('NFKD', self.figureName).encode('ascii', 'ignore')
         # in case we have path/to/name, just use name
         name = path.basename(name)
 
@@ -186,7 +187,7 @@ class FigureExport(object):
         for each page.
         Then we add an info page and create a zip of everything if needed.
         Finally the created file or zip is uploaded to OMERO and attached
-        as a file annotation to all the images in the figure. 
+        as a file annotation to all the images in the figure.
         """
 
         # test to see if we've got multiple pages
@@ -375,7 +376,7 @@ class FigureExport(object):
         Add the panel labels to the page.
         Here we calculate the position of labels but delegate
         to self.drawText() to actually place the labels on PDF/TIFF
-        """ 
+        """
         labels = panel['labels']
         x = panel['x']
         y = panel['y']
@@ -416,7 +417,6 @@ class FigureExport(object):
             l['size'] = int(l['size'])   # make sure 'size' is number
             if pos in positions:
                 positions[pos].append(l)
-
 
         def drawLab(label, lx, ly, align='left'):
             label_h = label['size']
@@ -496,14 +496,13 @@ class FigureExport(object):
                     lx = lx - l['size'] - spacer
                     drawLab(l, lx, ly, align='vertical')
 
-
     def drawScalebar(self, panel, region_width, page):
         """
         Add the scalebar to the page.
         Here we calculate the position of scalebar but delegate
         to self.drawLine() and self.drawText() to actually place
         the scalebar and label on PDF/TIFF
-        """ 
+        """
         x = panel['x']
         y = panel['y']
         width = panel['width']
@@ -532,7 +531,7 @@ class FigureExport(object):
 
         position = 'position' in sb and sb['position'] or 'bottomright'
         print 'scalebar.position', position
-        align='left'
+        align = 'left'
 
         if position == 'topleft':
             lx = x + spacer
@@ -549,7 +548,6 @@ class FigureExport(object):
             ly = y + height - spacer
             align = "right"
 
-
         print "Adding Scalebar of %s microns." % sb['length'],
         print "Pixel size is %s microns" % panel['pixel_size_x']
         pixels_length = sb['length'] / panel['pixel_size_x']
@@ -565,7 +563,6 @@ class FigureExport(object):
             lx_end = lx - canvas_length
 
         self.drawLine(lx, ly, lx_end, ly, 2, (red, green, blue))
-
 
         if 'show_label' in sb and sb['show_label']:
             # c = self.figureCanvas
@@ -735,13 +732,13 @@ class FigureExport(object):
         # Some html from markdown may not be compatible
         # with adding to PDF.
         try:
-            para=Paragraph(text, style)
+            para = Paragraph(text, style)
         except ValueError:
             print "Couldn't add paragraph to PDF:"
             print text
             text = "[Failed to format paragraph - not shown]"
-            para=Paragraph(text, style)
-        w,h = para.wrap(aW, pageY) # find required space
+            para = Paragraph(text, style)
+        w, h = para.wrap(aW, pageY)   # find required space
         if thumbSrc is not None:
             parah = max(h, imgh)
         else:
@@ -756,7 +753,7 @@ class FigureExport(object):
             c.drawImage(thumbSrc, inch, pageY - imgh, imgw, imgh)
             indent = indent + imgw + spacer
         para.drawOn(c, indent, pageY - h)
-        return pageY - parah - spacer # reduce the available height
+        return pageY - parah - spacer  # reduce the available height
 
     def addReadMeFile(self):
         """ Add a simple text file into the zip to explain what's there """
@@ -800,7 +797,6 @@ class FigureExport(object):
             figureLink = "Link to Figure: <a href='%s' color='blue'>%s</a>" % (fileUrl, fileUrl)
             pageY = self.addParaWithThumb(figureLink, pageY, style=styleN)
 
-
         # Add Figure Legend
         if 'legend' in self.figure_json and len(self.figure_json['legend']) > 0:
             pageY = self.addParaWithThumb("Legend:", pageY, style=styleH3)
@@ -810,7 +806,7 @@ class FigureExport(object):
                 # convert markdown to html
                 legend = markdown.markdown(legend)
                 # insert 'blue' style into any links
-                legend = legend.replace("<a href", "<a color='blue' href");
+                legend = legend.replace("<a href", "<a color='blue' href")
                 # Add paragraphs separately
                 paraLines = legend.split("<p>")
                 for p in paraLines:
@@ -819,7 +815,6 @@ class FigureExport(object):
             else:
                 print "Markdown not imported. See https://pythonhosted.org/Markdown/install.html"
                 pageY = self.addParaWithThumb(legend, pageY, style=styleN)
-
 
         pageY = self.addParaWithThumb("Figure contains the following images:", pageY, style=styleH3)
 
@@ -851,8 +846,7 @@ class FigureExport(object):
             scalebars = list(set(scalebars))
             pageY = self.addParaWithThumb("Scalebars:", pageY, style=styleH3)
             pageY = self.addParaWithThumb("Scalebar Lengths: %s" % ", ".join(scalebars),
-                    pageY, style=styleN)
-
+                                          pageY, style=styleN)
 
     def panel_is_on_page(self, panel, page):
         """ Return true if panel overlaps with this page """
@@ -866,7 +860,6 @@ class FigureExport(object):
         cy2 = cy + self.pageHeight
         #overlap needs overlap on x-axis...
         return px < cx2 and cx < px2 and py < cy2 and cy < py2
-
 
     def add_panels_to_page(self, panels_json, imageIds, page):
         """ Add panels that are within the bounds of this page """
@@ -884,7 +877,6 @@ class FigureExport(object):
                 imageIds.add(imageId)
             self.drawLabels(panel, page)
             print ""
-
 
     def getFigureFileExt(self):
         return "pdf"
@@ -979,7 +971,6 @@ class FigureExport(object):
         self.figureCanvas.drawImage(imgName, x, y, width, height)
 
 
-
 class TiffExport(FigureExport):
     """
     Subclass to handle export of Figure as TIFFs, 1 per page.
@@ -1026,7 +1017,6 @@ class TiffExport(FigureExport):
         print "TIFF: width, height", tiffWidth, tiffHeight
         self.tiffFigure = Image.new("RGBA", (tiffWidth, tiffHeight), (255, 255, 255))
 
-
     def pasteImage(self, pilImg, imgName, x, y, width, height, dpi=None):
         """ Add the PIL image to the current figure page """
 
@@ -1058,7 +1048,6 @@ class TiffExport(FigureExport):
         width, height = pilImg.size
         box = (x, y, x + width, y + height)
         self.tiffFigure.paste(pilImg, box)
-
 
     def drawLine(self, x, y, x2, y2, width, rgb):
         """ Draw line on the current figure page """
@@ -1093,7 +1082,7 @@ class TiffExport(FigureExport):
             tempLabel = Image.new('RGBA', (txt_w, txt_h), (255, 255, 255, 0))
             textdraw = ImageDraw.Draw(tempLabel)
             textdraw.text((0, 0), text, font=font, fill=rgb)
-            w=tempLabel.rotate(90)
+            w = tempLabel.rotate(90)
             # Use label as mask, so transparent part is not pasted
             y = y - (w.size[1]/2)
             self.tiffFigure.paste(w, (x, y), mask=w)
@@ -1102,7 +1091,7 @@ class TiffExport(FigureExport):
             y = self.scaleCoords(y)
             textdraw = ImageDraw.Draw(self.tiffFigure)
             if align == "center":
-                x = x - (txt_w/ 2)
+                x = x - (txt_w / 2)
             elif align == "right":
                 x = x - txt_w
             textdraw.text((x, y), text, font=font, fill=rgb)
@@ -1143,7 +1132,6 @@ class TiffExport(FigureExport):
         if not reportlabInstalled:
             return
         self.figureCanvas.save()
-
 
 
 def export_figure(conn, scriptParams):

--- a/static/figure/css/figure.css
+++ b/static/figure/css/figure.css
@@ -266,7 +266,7 @@
     }
 
     .scalebar {
-        height: 2px;
+        height: 3px;
         position: absolute;
         margin: 5% !important;
     }

--- a/static/figure/js/app.js
+++ b/static/figure/js/app.js
@@ -95,8 +95,9 @@ $(function(){
                             if (fileId && canEdit) {
                                 options.fileId = fileId;
                             } else {
-                                var figureName = prompt("Enter Figure Name", "unsaved");
-                                options.figureName = figureName || "unsaved";
+                                var defaultName = figureModel.getDefaultFigureName();
+                                var figureName = prompt("Enter Figure Name", defaultName);
+                                options.figureName = figureName || defaultName;
                             }
                             options.success = doClear;
                             figureModel.save_to_OMERO(options);

--- a/static/figure/js/models/figure_model.js
+++ b/static/figure/js/models/figure_model.js
@@ -196,6 +196,13 @@
             return {'w': w, 'h': h, 'cols': cols, 'rows': rows}
         },
 
+        getDefaultFigureName: function() {
+            var d = new Date(),
+                dt = d.getFullYear() + "-" + (d.getMonth()+1) + "-" +d.getDate(),
+                tm = d.getHours() + ":" + d.getMinutes() + ":" + d.getSeconds();
+            return "Figure_" + dt + "_" + tm;
+        },
+
         nudge_right: function() {
             this.nudge('x', 10);
         },

--- a/static/figure/js/models/panel_model.js
+++ b/static/figure/js/models/panel_model.js
@@ -356,6 +356,28 @@
             this.set({'width': newW, 'height': newH, 'dx': dx, 'dy': dy, 'zoom': zoom});
         },
 
+        // returns the current viewport as a Rect {x, y, width, height}
+        getViewportAsRect: function() {
+            var zoom = this.get('zoom'),
+                dx = this.get('dx'),
+                dy = this.get('dy'),
+                width = this.get('width'),
+                height = this.get('height');
+
+            var xPercent = width / this.get('orig_width'),
+                yPercent = height / this.get('orig_height'),
+                scale = Math.max(xPercent, yPercent);
+
+            var roiW = width * scale,
+                roiH = height * scale;
+            var cX = width/2 + dx,
+                cY = height/2 + dy,
+                roiX = cX - (roiW / 2),
+                roiY = cY - (roiH / 2);
+
+            return {'x': roiX, 'y': roiY, 'width': roiW, 'heigh': roiH};
+        },
+
         // Drag resizing - notify the PanelView without saving
         drag_resize: function(x, y, w, h) {
             this.trigger('drag_resize', [x, y, w, h] );

--- a/static/figure/js/models/panel_model.js
+++ b/static/figure/js/models/panel_model.js
@@ -362,20 +362,34 @@
                 dx = this.get('dx'),
                 dy = this.get('dy'),
                 width = this.get('width'),
-                height = this.get('height');
+                height = this.get('height'),
+                orig_width = this.get('orig_width'),
+                orig_height = this.get('orig_height');
 
-            var xPercent = width / this.get('orig_width'),
-                yPercent = height / this.get('orig_height'),
+            // find if scaling is limited by width OR height
+            var xPercent = width / orig_width,
+                yPercent = height / orig_height,
                 scale = Math.max(xPercent, yPercent);
 
-            var roiW = width * scale,
-                roiH = height * scale;
-            var cX = width/2 + dx,
-                cY = height/2 + dy,
+            // if not zoomed or panned and panel shape is approx same as image...
+            if (dx === 0 && dy === 0 && zoom == 100 && Math.abs(xPercent - yPercent) < 0.01) {
+                // ...ROI is whole image
+                return {'x': 0, 'y': 0, 'width': orig_width, 'height': orig_height}
+            }
+
+            // Factor in the applied zoom...
+            scale = scale * zoom / 100;
+            // ...to get roi width & height
+            var roiW = width / scale,
+                roiH = height / scale;
+
+            // Use offset from image centre to calculate ROI position
+            var cX = orig_width/2 - dx,
+                cY = orig_height    /2 - dy,
                 roiX = cX - (roiW / 2),
                 roiY = cY - (roiH / 2);
 
-            return {'x': roiX, 'y': roiY, 'width': roiW, 'heigh': roiH};
+            return {'x': roiX, 'y': roiY, 'width': roiW, 'height': roiH};
         },
 
         // Drag resizing - notify the PanelView without saving

--- a/static/figure/js/views/figure_view.js
+++ b/static/figure/js/views/figure_view.js
@@ -400,10 +400,7 @@
             options = options || {};
             var defaultName = this.model.get('figureName');
             if (!defaultName) {
-                var d = new Date(),
-                    dt = d.getFullYear() + "-" + (d.getMonth()+1) + "-" +d.getDate(),
-                    tm = d.getHours() + ":" + d.getMinutes() + ":" + d.getSeconds();
-                defaultName = "Figure_" + dt + "_" + tm;
+                defaultName = this.model.getDefaultFigureName();
             } else {
                 defaultName = defaultName + "_copy";
             }

--- a/static/figure/js/views/legend_view.js
+++ b/static/figure/js/views/legend_view.js
@@ -17,9 +17,8 @@
 
 var LegendView = Backbone.View.extend({
 
-        el: $("#js-legend"),
-
-        // template: JST["static/figure/templates/paper_setup_modal_template.html"],
+        // Use 'body' to handle Menu: File > Add Figure Legend
+        el: $("body"),
 
         model:FigureModel,
 
@@ -104,11 +103,12 @@ var LegendView = Backbone.View.extend({
             var self = this,
                 legendText = this.model.get('legend') || "",
                 legendCollapsed = this.model.get('legend_collapsed'),
-                $edit = $('.edit-legend', self.el),
-                $save = $('.save-legend', self.el),
-                $cancel = $('.cancel-legend', self.el),
-                $panel = $('.panel', self.el),
-                $legend = $('.legend', self.el);
+                $el = $("#js-legend"),
+                $edit = $('.edit-legend', $el),
+                $save = $('.save-legend', $el),
+                $cancel = $('.cancel-legend', $el),
+                $panel = $('.panel', $el),
+                $legend = $('.legend', $el);
 
             self.renderCollapsed(legendCollapsed);
 
@@ -133,10 +133,12 @@ var LegendView = Backbone.View.extend({
                 $panel.removeClass('editing');
                 if (legendText.length === 0) {
                     $panel.hide();
+                    $edit.text("Add Figure Legend");
                 } else {
                     $panel.show();
                     legendText = markdown.toHTML( legendText );
                     $legend.html(legendText);
+                    $edit.text("Edit Figure Legend");
                 }
             }
         }

--- a/static/figure/js/views/legend_view.js
+++ b/static/figure/js/views/legend_view.js
@@ -39,6 +39,25 @@ var LegendView = Backbone.View.extend({
             "click .collapse-legend": "collapseLegend",
             "click .expand-legend": "expandLegend",
             "click .markdown-info": "markdownInfo",
+            "click .panel-body p": "legendClick",
+        },
+
+        // Click on the legend <p>. Start editing or follow link
+        legendClick: function(event) {
+            event.preventDefault();
+            // If link, open new window / tab
+            if (event.target.nodeName.toLowerCase() == "a") {
+                var href = event.target.getAttribute('href');
+                window.open(href, '_blank');
+                return false;
+            // Click on legend text expands then edits legend
+            } else {
+                if (this.model.get("legend_collapsed")) {
+                    this.expandLegend();
+                } else {
+                    this.editLegend();
+                }
+            }
         },
 
         markdownInfo: function(event) {
@@ -67,7 +86,7 @@ var LegendView = Backbone.View.extend({
         },
 
         editLegend: function(event) {
-            event.preventDefault();
+            if (event) event.preventDefault();
             this.editing = true;
             if (this.model.get("legend_collapsed")) {
                 this.model.set("legend_collapsed", false);
@@ -121,7 +140,7 @@ var LegendView = Backbone.View.extend({
 
                 $panel.addClass('editing');
                 $panel.show();
-                var html = '<textarea class="form-control" rows="7" style="resize:none">'
+                var html = '<textarea class="form-control" rows="9" style="resize:none">'
                             + legendText + '</textarea>';
                 $legend.html(html);
             } else {

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -13,10 +13,25 @@ var RoiModalView = Backbone.View.extend({
         initialize: function() {
 
             var self = this;
+
+            // Here we handle init of the dialog when it's shown...
             $("#roiModal").bind("show.bs.modal", function(){
+                // Clone the 'first' selected panel as our reference for everything
                 self.m = self.model.getSelected().head().clone();
                 self.listenTo(self.m, 'change:theZ change:theT', self.render);
-                self.cropModel.set({'selected': false, 'width': 0, 'height': 0});    // hide crop roi
+                // set selected area
+                // var roi = self.m.getViewportAsRect();
+
+                // console.log(roi);
+                // self.cropModel.set(roi);
+                self.cropModel.set({'selected': true, 'width': 100, 'height': 100});
+
+                // if (self.m.get('zoom') > 100) {
+
+                // } else {
+                //     // hide crop roi
+                //     self.cropModel.set({'selected': false, 'width': 0, 'height': 0});
+                // }
                 self.zoomToFit();   // includes render()
                 // disable submit until user chooses a region/ROI
                 self.enableSubmit(false);

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -166,7 +166,7 @@ var RoiModalView = Backbone.View.extend({
                         'y': r.y,
                         'width': r.width,
                         'height': r.height,
-                        'theZ': z,
+                        'theZ': self.m.get('theZ'),
                         'theT': t,
                     }
                 return rv;

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -212,12 +212,13 @@ var RoiModalView = Backbone.View.extend({
 
             // Don't set Z/T if we already have different Z/T indecies.
             sel.each(function(m){
-                var sh = getShape(m.get('theZ'), m.get('theT'));
+                var sh = getShape(m.get('theZ'), m.get('theT')),
+                    newZ = Math.min(parseInt(sh.theZ, 10), m.get('sizeZ') - 1),
+                    newT = Math.min(parseInt(sh.theT, 10), m.get('sizeT') - 1);
 
                 m.cropToRoi({'x': sh.x, 'y': sh.y, 'width': sh.width, 'height': sh.height});
                 // 'save' to trigger 'unsaved': true
-                m.save({'theZ': parseInt(sh.theZ, 10),
-                       'theT': parseInt(sh.theT, 10)});
+                m.save({'theZ': newZ, 'theT': newT});
             });
             $("#roiModal").modal('hide');
         },

--- a/static/figure/js/views/roi_modal_view.js
+++ b/static/figure/js/views/roi_modal_view.js
@@ -19,19 +19,22 @@ var RoiModalView = Backbone.View.extend({
                 // Clone the 'first' selected panel as our reference for everything
                 self.m = self.model.getSelected().head().clone();
                 self.listenTo(self.m, 'change:theZ change:theT', self.render);
-                // set selected area
-                // var roi = self.m.getViewportAsRect();
 
-                // console.log(roi);
-                // self.cropModel.set(roi);
-                self.cropModel.set({'selected': true, 'width': 100, 'height': 100});
+                self.cropModel.set({'selected': false, 'width': 0, 'height': 0});
 
-                // if (self.m.get('zoom') > 100) {
+                // get selected area
+                var roi = self.m.getViewportAsRect();
 
-                // } else {
-                //     // hide crop roi
-                //     self.cropModel.set({'selected': false, 'width': 0, 'height': 0});
-                // }
+                // Show as ROI *if* it isn't the whole image
+                if (roi.x !== 0 || roi.y !== 0
+                        || roi.width !== self.m.get('orig_width')
+                        || roi.height !== self.m.get('orig_height')) {
+                    self.currentROI = roi;
+                    self.cropModel.set({
+                        'selected': true
+                    });
+                }
+
                 self.zoomToFit();   // includes render()
                 // disable submit until user chooses a region/ROI
                 self.enableSubmit(false);

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -510,6 +510,10 @@
                             <li class="paper_setup">
                                 <a href="#">Paper Setup...</a>
                             </li>
+                            <!-- Handled by LegendView -->
+                            <li class="edit-legend">
+                                <a href="#">Add Figure Legend...</a>
+                            </li>
                          </ul>
                     </li>
 
@@ -703,7 +707,7 @@
             </button>
             <button type="button" class="btn btn-default btn-xs edit-legend"
                 title="Add figure legend" style="margin: 3px">
-                Edit Figure Legend
+                Add Figure Legend
             </button>
         </div>
     </div>

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -396,7 +396,7 @@
                         <tr>
                             <th>LINKS</th>
                             <td>Add links with [Link text](http://link_url.com)</td>
-                            <td>Add links with <a href="http://link_url.com">Link text</a></td>
+                            <td>Add links with <a href="#">Link text</a></td>
                         </tr>
                        <!--  <tr><td>You need to use 2 line breaks between paragraphs</td><td></td></tr> -->
                     </table>


### PR DESCRIPTION
A bunch of follow-ups that came from OMERO.figure 1.1.0 release testing.

To test:
 - When prompted to Save a newly created file when using browser back button, default name is same as elsewhere (not 'unsaved').
 - Menu: File > Add Figure Legend  to add or edit a figure legend.
 - Exporting 'with images' adds a README.txt file to the zip to explain what images are in the directories.
 - Scalebars are 50% thicker, both in the web UI and exported figures.
 - Legend formatting dialog link doesn't open new page etc.
 - Clicking figure legend when collapsed expands it. Clicking when expanded starts edit.
 - Clicking links within figure legend opens in new tab/window.
 - Crop dialog should add the current panel region as initial crop selection (if zoomed in at-all).
 - Export without saving works.